### PR TITLE
Implement Vowpal Wabbit installation for Ansible Playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a set of Ansible playbooks to easily install a set of distribute
   * [Launch/Terminate EC2 instances on AWS](#ec2)
   * [Zookeeper](#zookeeper)
   * [Kafka](#kafka)
+  * [Vowpal Wabbit](#vowpal-wabbit)
 
 ## Supported playbooks
 * EC2
@@ -22,7 +23,7 @@ This project is a set of Ansible playbooks to easily install a set of distribute
 ~$ ansible-playbook <master-playbook>.yml --extra-vars "<var1>=<value1> <var2>=<value2>" --tags "<tag1>,<tag2>"
 ```
 * **EC2** playbook is controlled by a yaml file containing variables for the EC2 instances to be acted on. More details [below](#ec2)
-* **Zookeeper** and **Kafka** playbooks need respective cluster tags to be specified to identify which nodes are in the cluster and need to be acted on. More details [below](#zookeeper)
+* **Zookeeper**, **Kafka**, and **Vowpal Wabbit** playbooks need respective cluster tags to be specified to identify which nodes are in the cluster and need to be acted on. More details [below](#zookeeper)
 
 ## Setup
 ### On your local/remote machine
@@ -194,3 +195,14 @@ This project is a set of Ansible playbooks to easily install a set of distribute
     ~$ ansible-playbook ./kafka.yml --extra-vars "zookeeper_tag=<cluster_tag> kafka_tag=<cluster_tag>" --tags uninstall --skip-tags zookeeper
 
     ```
+
+ *  #### Vowpal Wabbit   
+
+Vowpal Wabbit is a fast out-of-core Machine Learning system. Installation can take upwards of 10 minutes on micro instances, as it compiles a lot of C++ with high optimization levels using Clang. 
+
+  * ####Install Vowpal Wabbit:
+
+    ```bash
+    ~$ ansible-playbook ./vw.yml --extra-vars "vw_tag=class_vw" --tags install
+    ```
+

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ This project is a set of Ansible playbooks to easily install a set of distribute
 
     The `Name` tag in the `tag_key_vals` is mandatory to create an identifier for the instances. More tags can be added if needed but are optional.
 
+    In your terminal, you will likely also need to add your private key to an ssh agent:
+
+    ```bash
+    ssh-add </path/to/my.pem>
+    ```
+
   * ####Launch EC2 instances:
     
     ```bash

--- a/ec2_vars_vw_ajh.yml
+++ b/ec2_vars_vw_ajh.yml
@@ -1,0 +1,10 @@
+---
+key_pair: adam-heller
+instance_type: t2.micro
+region: us-west-2
+security_group_id: sg-2b6cf950
+num_instances: 2
+subnet_id: subnet-d7db7ab0
+tag_key_vals:
+  Name: aj-ec2-test
+  class: vw

--- a/roles/vw/tasks/apt.yml
+++ b/roles/vw/tasks/apt.yml
@@ -1,0 +1,2 @@
+- name: Testing apt
+  apt: "name=make state=installed"

--- a/roles/vw/tasks/install.yml
+++ b/roles/vw/tasks/install.yml
@@ -1,0 +1,38 @@
+---
+- name: Ensure vw's dependencies are installed
+  become: yes
+  apt: "name={{ item }} state=installed"
+  with_items:
+    - make
+    - libboost-program-options-dev 
+    - zlib1g-dev
+    - libboost-python-dev
+    - clang
+  register: vw_dependencies_deb
+  when: ansible_os_family == 'Debian'
+
+- name: Clone the vw repo
+  become: no
+  git:
+    repo: 'git://github.com/JohnLangford/vowpal_wabbit.git'
+    dest: "{{ BUILD_DIR }}"
+  register: vw_cloned
+  when: vw_dependencies_deb|success
+
+- name: Build vw
+  become: no
+  command: make CXX=clang++ prefix={{ INSTALL_DIR }} {{ item }}
+  args:
+    chdir: vw-git
+  with_items:
+    - 
+    - test
+  when: vw_cloned|success
+  register: vw_built
+
+- name: Install vw
+  become: yes
+  command: make CXX=clang++ prefix={{ INSTALL_DIR }} install
+  args:
+    chdir: vw-git
+  when: vw_built|success

--- a/roles/vw/tasks/main.yml
+++ b/roles/vw/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Check if vw is installed
+  stat:
+    path: "{{ VW_HOME }}"
+  register: vw
+  tags: ['test', 'start', 'stop', 'install', 'uninstall', 'info']
+
+- name: Install Vowpal Wabbit
+  include: install.yml
+  tags: install
+  when: vw.stat.exists == False
+
+- name: Testing apt
+  include: test.yml
+  tags: test

--- a/roles/vw/tasks/test.yml
+++ b/roles/vw/tasks/test.yml
@@ -1,0 +1,5 @@
+- name: Testing
+  file:
+    path: "/home/ubuntu/bort"
+    owner: ubuntu
+    state: present

--- a/roles/vw/vars/main.yml
+++ b/roles/vw/vars/main.yml
@@ -1,0 +1,3 @@
+BUILD_DIR: /home/ubuntu/vw-git
+INSTALL_DIR: /usr/local
+VW_HOME: /usr/local/vw

--- a/vw.yml
+++ b/vw.yml
@@ -1,0 +1,18 @@
+---
+- name: Creating host group vowpal wabbit from dynamic inventory
+  hosts: localhost
+  connection: local
+  tags: ['info', 'install', 'start', 'stop', 'uninstall']
+  vars:
+    vw_tag_name: "tag_{{ vw_tag | replace('-', '_') }}"
+  tasks:
+    - add_host: name={{ item }} groups=vw
+      with_items: "{{ groups[vw_tag_name] }}"
+
+- name: Execute Vowpal Wabbit roles
+  hosts: vw
+  user: ubuntu
+  become: true
+  become_method: sudo
+  roles:
+    - role: vw


### PR DESCRIPTION
Currently only supports installation (which requires Clang for optimized compilation, installed via apt-get).

**Launch (create) cluster:** `sudo -E ansible-playbook ./ec2.yml --extra-vars vars_file="./ec2_vars_vw_ajh.yml" --tags launch`

**Install:** `sudo -E ansible-playbook ./vw.yml --extra-vars "vw_tag=class_vw" --tags install`
